### PR TITLE
deleted babelrc configuration file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-    "presets": ["next/babel"]
-}


### PR DESCRIPTION
Enabled [Next.js Compiler](https://nextjs.org/docs/advanced-features/compiler) by deleting custom `.babelrc` that we do not need