### PR TITLE
Ignore all next-pwa generated public files (including .map)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,10 @@
 /out/
 
 # next-pwa
-**/public/workbox-*.js
-**/public/sw.js
-**/public/worker-*.js
-**/public/fallback-*.js
+**/public/workbox-*
+**/public/sw.*
+**/public/worker-*
+**/public/fallback-*
 
 # production
 /build


### PR DESCRIPTION
So far, gemerated `*.map` files were not ignored.